### PR TITLE
Rollback to Producer-Controlled Proxy pattern (Issue #13)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # @egulatee/pulumi-stack-alias
 
-A lightweight Pulumi library that enables **producer-controlled stack aliasing** through redirect pointers. Eliminates output staleness and operational overhead while keeping aliasing decisions with the infrastructure project.
+Producer-side stack aliasing for Pulumi using lightweight proxy stacks. Consumers use standard `StackReference` (zero library dependency), while producers use this library to create alias stacks that re-export outputs from canonical stacks.
 
 [![CI](https://github.com/egulatee/pulumi-stack-alias/actions/workflows/ci.yml/badge.svg)](https://github.com/egulatee/pulumi-stack-alias/actions/workflows/ci.yml)
 [![npm version](https://badge.fury.io/js/@egulatee%2Fpulumi-stack-alias.svg)](https://www.npmjs.com/package/@egulatee/pulumi-stack-alias)
@@ -11,51 +11,67 @@ A lightweight Pulumi library that enables **producer-controlled stack aliasing**
 When managing infrastructure across multiple environments (dev, staging, prod), consumer projects need to reference shared infrastructure stacks. Traditional approaches either:
 - Force consumers to know which stack holds the real resources
 - Scatter mapping logic across every consumer project
-- Create heavy proxy stacks that re-export all outputs (causing staleness)
+- Require complex consumer-side resolvers with library dependencies
 
 **The aliasing decision belongs with the producer (infrastructure project), not the consumer.**
 
-## Solution: Producer-Controlled Redirect
+## Solution: Producer-Controlled Proxy Stacks
 
-Alias stacks export a single `_canonicalStack` redirect pointer instead of re-exporting all outputs. The consumer-side resolver transparently follows redirects to reach the canonical stack, ensuring outputs are always fresh.
+Alias stacks re-export outputs from canonical stacks. Consumers use standard Pulumi `StackReference` with **no library dependency**. Producers use this library to create lightweight proxy stacks.
 
 ### How It Works
 
 ```
 infrastructure/shared    → canonical stack, exports real resources
-infrastructure/dev       → alias stack, exports only { _canonicalStack: "shared" }
-infrastructure/staging   → alias stack, exports only { _canonicalStack: "shared" }
-infrastructure/prod      → canonical stack (no _canonicalStack), exports real resources
+infrastructure/dev       → proxy stack, re-exports outputs from shared
+infrastructure/staging   → proxy stack, re-exports outputs from shared
+infrastructure/prod      → canonical stack, exports real resources
 ```
 
-Consumer calls `resolveStackRef("infrastructure")`:
-1. Creates a `StackReference` to `infrastructure/${currentStack}` (e.g., `infrastructure/dev`)
-2. Checks for `_canonicalStack` output
-3. If present, follows the redirect to `infrastructure/shared`
-4. If absent, returns the current reference (already canonical)
+Consumer uses standard Pulumi:
+```typescript
+const stack = new pulumi.StackReference(`org/infrastructure/${pulumi.getStack()}`);
+const vpcId = stack.requireOutput("vpcId");
+```
+
+**Zero consumer dependencies!** The consumer has no knowledge of aliasing. When `application/dev` deploys, it reads `infrastructure/dev`, which is a proxy stack that re-exports outputs from `infrastructure/shared`.
 
 ## Installation
 
+**Producer projects only:**
 ```bash
 npm install @egulatee/pulumi-stack-alias
 ```
+
+**Consumer projects:** No installation needed! Use standard Pulumi `StackReference`.
 
 ## Usage
 
 ### Producer Side (Infrastructure Project)
 
-Create lightweight alias stacks that export only a redirect pointer:
+Create alias stacks that re-export outputs from canonical stacks:
+
+#### Simple Alias
 
 ```typescript
 // infrastructure/index.ts
+import { createStackAlias } from "@egulatee/pulumi-stack-alias";
 import * as pulumi from "@pulumi/pulumi";
 
 const config = new pulumi.Config();
 const aliasTarget = config.get("aliasTarget");
 
 if (aliasTarget) {
-  // This is an alias stack — export only the redirect pointer
-  export const _canonicalStack = aliasTarget;
+  // This is an alias stack — re-export outputs from target
+  const alias = createStackAlias({
+    targetProject: "infrastructure",
+    targetStack: aliasTarget,
+    outputs: ["vpcId", "endpoint", "clusterName"],
+  });
+
+  export const vpcId = alias.vpcId;
+  export const endpoint = alias.endpoint;
+  export const clusterName = alias.clusterName;
 } else {
   // This is a canonical stack — create actual resources
   const vpc = new aws.ec2.Vpc("main", {
@@ -63,8 +79,8 @@ if (aliasTarget) {
   });
 
   export const vpcId = vpc.id;
-  export const clusterName = pulumi.output("my-cluster");
   export const endpoint = pulumi.output("https://api.example.com");
+  export const clusterName = pulumi.output("my-cluster");
 }
 ```
 
@@ -88,29 +104,58 @@ config:
   # No aliasTarget — this is a canonical stack (separate from shared)
 ```
 
-Deploy your stacks:
+#### Conditional Alias (Pattern-Based)
 
-```bash
-# Deploy canonical stacks (creates real resources)
-pulumi up --stack shared
-pulumi up --stack prod
+For automatic aliasing without config:
 
-# Deploy alias stacks (one-time, trivial — just sets a pointer)
-pulumi up --stack dev
-pulumi up --stack staging
+```typescript
+// infrastructure/index.ts
+import { createConditionalAlias } from "@egulatee/pulumi-stack-alias";
+
+const alias = createConditionalAlias({
+  targetProject: "infrastructure",
+  patterns: [
+    { pattern: "*/prod", target: "prod" },
+    { pattern: "*/staging", target: "shared" },
+    { pattern: "*/dev", target: "shared" },
+    { pattern: "*/*-ephemeral", target: "shared" },
+  ],
+  defaultTarget: "shared",
+  outputs: ["vpcId", "endpoint", "clusterName"],
+});
+
+export const vpcId = alias.vpcId;
+export const endpoint = alias.endpoint;
+export const clusterName = alias.clusterName;
+```
+
+#### Simple API
+
+Simplified API for common cases:
+
+```typescript
+import { createSimpleAlias } from "@egulatee/pulumi-stack-alias";
+
+const alias = createSimpleAlias("infrastructure", "shared", ["vpcId"]);
+export const vpcId = alias.vpcId;
 ```
 
 ### Consumer Side (Application Project)
 
-Use the resolver to transparently follow redirects:
+Use standard Pulumi `StackReference` — **no library dependency**:
 
 ```typescript
 // application/index.ts
 import * as pulumi from "@pulumi/pulumi";
-import { resolveStackRef } from "@egulatee/pulumi-stack-alias";
+import * as aws from "@pulumi/aws";
 
-const infraStack = resolveStackRef("infrastructure");
-const vpcId = infraStack.apply(ref => ref.requireOutput("vpcId"));
+// Standard Pulumi StackReference — no special library needed!
+const infraStack = new pulumi.StackReference(
+  `${pulumi.getOrganization()}/infrastructure/${pulumi.getStack()}`
+);
+
+const vpcId = infraStack.requireOutput("vpcId");
+const endpoint = infraStack.requireOutput("endpoint");
 
 const subnet = new aws.ec2.Subnet("app-subnet", {
   vpcId: vpcId,
@@ -118,57 +163,139 @@ const subnet = new aws.ec2.Subnet("app-subnet", {
 });
 ```
 
-The consumer has **zero knowledge** of the aliasing. When `application/dev` deploys:
-1. Resolver reads `infrastructure/dev`
-2. Finds `_canonicalStack: "shared"`
-3. Returns `StackReference` to `infrastructure/shared`
-4. Outputs are always fresh from the canonical stack!
+The consumer has **zero knowledge** of aliasing. When `application/dev` deploys:
+1. Reads `infrastructure/dev` (a proxy stack)
+2. Gets outputs (re-exported from `infrastructure/shared`)
+3. No library dependency required!
 
 ## Deployment Flow
 
-```bash
-# Deploy canonical stack (creates real resources)
-pulumi up --stack shared
+### Initial Setup
 
-# Deploy alias stacks (one-time, trivial)
+```bash
+# Deploy canonical stacks (creates real resources)
+pulumi up --stack shared
+pulumi up --stack prod
+
+# Deploy alias stacks (creates proxy outputs)
 pulumi up --stack dev
 pulumi up --stack staging
 
 # Consumer deployments — no alias awareness needed
 cd application && pulumi up --stack dev
-# → resolver reads infrastructure/dev
-# → follows _canonicalStack
-# → reads infrastructure/shared
 ```
 
-## Why Output Staleness Is Gone
+### Keeping Outputs Fresh
 
-Alias stacks export only `_canonicalStack: "shared"` — a string that almost never changes. The actual resource outputs (VPC IDs, endpoints, cluster names) are read **live** from the canonical stack at consumer deploy time.
+Alias stacks capture outputs at deploy time. When canonical stack outputs change, redeploy aliases:
 
-You only need to redeploy an alias stack if the redirect itself changes (e.g., moving `dev` from `shared` to its own dedicated stack).
+```bash
+# Update canonical stack
+pulumi up --stack shared
+
+# Sync alias stacks (fast — no real resources)
+pulumi up --stack dev
+pulumi up --stack staging
+```
+
+### CI/CD Orchestration
+
+Automate alias synchronization in CI/CD:
+
+```yaml
+# .github/workflows/deploy.yml
+jobs:
+  deploy-canonical:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy shared stack
+        run: pulumi up --stack shared --yes
+
+  sync-aliases:
+    needs: deploy-canonical
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        stack: [dev, staging]
+    steps:
+      - name: Sync alias stack
+        run: pulumi up --stack ${{ matrix.stack }} --yes
+```
+
+Alias deployments are fast (seconds) since they create no real resources — just re-export outputs.
 
 ## API Reference
 
-### `resolveStackRef(project, opts?)`
+### `createStackAlias(config)`
 
-Resolves a stack reference by checking for producer-controlled redirects.
+Creates a stack alias that re-exports outputs from a target stack.
 
 **Parameters:**
-- `project` (string) - Target project name (e.g., `"infrastructure"`)
-- `opts` (optional)
-  - `org` (string) - Target organization (defaults to current org)
+- `config.targetProject` (string) - Target project name
+- `config.targetStack` (string) - Target stack name
+- `config.targetOrg` (optional string) - Target organization (defaults to current org)
+- `config.outputs` (string[]) - List of output names to re-export
 
-**Returns:** `pulumi.Output<pulumi.StackReference>` - The resolved stack reference
+**Returns:** `AliasExports` - Record of Pulumi Outputs
 
 **Example:**
 ```typescript
-const infraStack = resolveStackRef("infrastructure");
-const vpcId = infraStack.apply(ref => ref.requireOutput("vpcId"));
+const alias = createStackAlias({
+  targetProject: "infrastructure",
+  targetStack: "shared",
+  outputs: ["vpcId", "endpoint"],
+});
+
+export const vpcId = alias.vpcId;
+export const endpoint = alias.endpoint;
+```
+
+### `createConditionalAlias(config)`
+
+Creates a conditional alias based on pattern matching.
+
+**Parameters:**
+- `config.targetProject` (string) - Target project name
+- `config.patterns` (PatternRule[]) - Pattern matching rules (evaluated in order, first match wins)
+- `config.defaultTarget` (optional string) - Default target if no pattern matches
+- `config.targetOrg` (optional string) - Target organization (defaults to current org)
+- `config.outputs` (string[]) - List of output names to re-export
+
+**Returns:** `AliasExports` - Record of Pulumi Outputs
+
+**Example:**
+```typescript
+const alias = createConditionalAlias({
+  targetProject: "infrastructure",
+  patterns: [
+    { pattern: "*/prod", target: "prod" },
+    { pattern: "*/dev", target: "shared" },
+  ],
+  defaultTarget: "shared",
+  outputs: ["vpcId"],
+});
+```
+
+### `createSimpleAlias(targetProject, targetStack, outputs)`
+
+Simplified API for creating aliases.
+
+**Parameters:**
+- `targetProject` (string) - Target project name
+- `targetStack` (string) - Target stack name
+- `outputs` (string[]) - List of output names to re-export
+
+**Returns:** `AliasExports` - Record of Pulumi Outputs
+
+**Example:**
+```typescript
+const alias = createSimpleAlias("infrastructure", "shared", ["vpcId"]);
+export const vpcId = alias.vpcId;
 ```
 
 ### `matchesPattern(pattern, project, stack)`
 
-Pattern matching with wildcard support. Useful for producer-side conditional logic.
+Pattern matching with wildcard support.
 
 **Wildcard rules:**
 - `*` matches any value
@@ -180,164 +307,179 @@ Pattern matching with wildcard support. Useful for producer-side conditional log
 ```typescript
 import { matchesPattern } from "@egulatee/pulumi-stack-alias";
 
-if (matchesPattern("*/dev", currentProject, currentStack)) {
-  export const _canonicalStack = "shared";
-}
+matchesPattern("*/dev", "myproject", "dev")        // true
+matchesPattern("*/*-ephemeral", "app", "pr-123-ephemeral")  // true
+matchesPattern("app-*/prod-*", "app-api", "prod-us")        // true
 ```
 
-### Constants
+## Pattern Format
 
-#### `REDIRECT_KEY`
+Patterns follow the format: `"projectPattern/stackPattern"`
 
-The output key used to indicate a stack is an alias: `"_canonicalStack"`
-
-## Pattern Matching for Producer Logic
-
-You can use pattern matching in your producer project to conditionally set redirects:
-
-```typescript
-// infrastructure/index.ts
-import * as pulumi from "@pulumi/pulumi";
-import { matchesPattern } from "@egulatee/pulumi-stack-alias";
-
-const project = pulumi.getProject();
-const stack = pulumi.getStack();
-
-// Pattern-based aliasing rules
-const patterns = [
-  { pattern: "*/dev", target: "shared" },
-  { pattern: "*/staging", target: "shared" },
-  { pattern: "*/*-ephemeral", target: "shared" },
-];
-
-let canonicalStack: string | undefined;
-for (const p of patterns) {
-  if (matchesPattern(p.pattern, project, stack)) {
-    canonicalStack = p.target;
-    break;
-  }
-}
-
-if (canonicalStack) {
-  // This is an alias stack
-  export const _canonicalStack = canonicalStack;
-} else {
-  // This is a canonical stack — create resources
-  export const vpcId = /* ... */;
-}
-```
+Examples:
+- `"*/dev"` - Any project, stack must be "dev"
+- `"myproject/*"` - Project must be "myproject", any stack
+- `"*/*-ephemeral"` - Any project, stack must end with "-ephemeral"
+- `"app-*/prod-*"` - Project must start with "app-", stack must start with "prod-"
 
 ## Comparison with Other Approaches
 
-| Concern | Full Proxy Stacks | Consumer Config | Producer-Controlled Redirect |
+| Concern | Producer Redirect (v0.1.0) | Producer Proxy (v0.2.0) | Consumer Config |
 |---|---|---|---|
-| Who owns mapping | Producer | Consumer | Producer ✓ |
-| Consumer config needed | None ✓ | Yes (per stack) | None ✓ |
-| Alias stack weight | Heavy (all outputs) | N/A | Trivial (one pointer) ✓ |
-| Output freshness | Stale until redeployed | Always live ✓ | Always live ✓ |
-| Redeploy aliases when canonical changes | Yes, every time | N/A | No ✓ |
-| Consumer code | `new StackReference(...)` ✓ | Custom resolver | `resolveStackRef(...)` |
-| Operational overhead | High | Low ✓ | Low ✓ |
+| Who owns mapping | Producer ✓ | Producer ✓ | Consumer |
+| Consumer library dependency | Yes | **None** ✓ | Varies |
+| Alias stack weight | Trivial (one pointer) | Light (output refs) | N/A |
+| Output freshness | Always live ✓ | Stale until redeployed* | Always live ✓ |
+| Consumer code | `resolveStackRef(...)` | `new StackReference(...)` ✓ | Custom |
+| CI/CD orchestration | Not needed | Recommended | Not needed |
+
+\* *Mitigated with CI/CD automation — alias deployments are fast (seconds)*
 
 ## Benefits
 
+✅ **Zero consumer dependencies** - Consumers use standard Pulumi `StackReference`
 ✅ **Producer-controlled** - Infrastructure projects own aliasing decisions
-✅ **Always fresh** - Outputs are read live from canonical stacks
-✅ **Lightweight** - Alias stacks export only a redirect pointer
-✅ **Zero consumer config** - Consumers have no aliasing awareness
-✅ **Flexible** - Easy to change mappings without touching consumers
 ✅ **Type-safe** - Full TypeScript support
+✅ **Flexible patterns** - Wildcard pattern matching for conditional aliasing
+✅ **CI/CD friendly** - Fast alias deployments (no real resources)
+✅ **Simple API** - Three functions cover all use cases
+
+## Trade-offs
+
+**Pros:**
+- Zero consumer library dependency
+- Standard Pulumi patterns
+- Simple mental model
+
+**Cons:**
+- Alias stacks need redeployment when canonical outputs change (mitigated with CI/CD)
+- Slightly more operational overhead than redirect pattern (but eliminates consumer dependencies)
 
 ## Use Cases
 
 ### Shared Development Infrastructure
 
-Deploy CI/CD infrastructure once on a shared cluster, route dev/staging to it:
+Deploy infrastructure once, route dev/staging to it:
 
-```yaml
-# infrastructure/Pulumi.dev.yaml
-config:
-  infrastructure:aliasTarget: shared
-
-# infrastructure/Pulumi.staging.yaml
-config:
-  infrastructure:aliasTarget: shared
+```typescript
+const alias = createConditionalAlias({
+  targetProject: "infrastructure",
+  patterns: [
+    { pattern: "*/prod", target: "prod" },
+  ],
+  defaultTarget: "shared",
+  outputs: ["vpcId", "endpoint"],
+});
 ```
 
-### Environment-Specific Production
+### Ephemeral PR Environments
 
-Production uses dedicated infrastructure, dev/staging share:
+Route ephemeral stacks to shared infrastructure:
 
-```yaml
-# infrastructure/Pulumi.prod.yaml
-config:
-  # No alias — dedicated prod infrastructure
-
-# infrastructure/Pulumi.dev.yaml
-config:
-  infrastructure:aliasTarget: shared
+```typescript
+const alias = createConditionalAlias({
+  targetProject: "infrastructure",
+  patterns: [
+    { pattern: "*/*-ephemeral", target: "shared" },
+    { pattern: "*/prod", target: "prod" },
+  ],
+  defaultTarget: "shared",
+  outputs: ["vpcId"],
+});
 ```
 
 ### Multi-Region Deployments
 
-Route regional stacks to regional canonical infrastructure:
+Route regional stacks to regional infrastructure:
 
-```yaml
-# infrastructure/Pulumi.us-east-1.yaml
-config:
-  infrastructure:aliasTarget: us-east
-
-# infrastructure/Pulumi.us-west-1.yaml
-config:
-  infrastructure:aliasTarget: us-west
+```typescript
+const alias = createConditionalAlias({
+  targetProject: "infrastructure",
+  patterns: [
+    { pattern: "*/us-*", target: "us-east" },
+    { pattern: "*/eu-*", target: "eu-west" },
+  ],
+  outputs: ["vpcId"],
+});
 ```
 
 ## Examples
 
 See the [examples](./examples) directory for complete implementations:
-- [Simple Redirect](./examples/simple-redirect) - Basic producer-controlled aliasing
-- [Pattern-Based](./examples/pattern-based) - Conditional redirect logic
+- [Simple Alias](./examples/simple-alias) - Basic proxy stack
+- [Conditional Alias](./examples/conditional-alias) - Pattern-based aliasing
 
-## Migration from Previous Versions
+## Migration Guide
 
-If you were using the old `createStackAlias()` pattern (full proxy stacks), migrate to the Producer-Controlled Redirect pattern:
+### From v0.1.0 (Redirect Pattern) to v0.2.0 (Proxy Pattern)
 
-**Before (v1.x - Full Proxy Stacks):**
+This is a **breaking change** — complete API rewrite.
+
+#### Producer Changes
+
+**Before (v0.1.0):**
 ```typescript
-// infrastructure/index.ts - OLD
-const alias = createStackAlias({
-  targetProject: "infrastructure",
-  targetStack: "shared",
-  outputs: ["vpcId", "endpoint"],
-});
-export const vpcId = alias.vpcId;
-export const endpoint = alias.endpoint;
-```
-
-**After (v2.x - Producer-Controlled Redirect):**
-```typescript
-// infrastructure/index.ts - NEW
+// infrastructure/index.ts
 const config = new pulumi.Config();
 const aliasTarget = config.get("aliasTarget");
 
 if (aliasTarget) {
   export const _canonicalStack = aliasTarget;
 } else {
-  export const vpcId = /* actual resource */;
-  export const endpoint = /* actual resource */;
+  export const vpcId = vpc.id;
 }
 ```
 
-**Consumer code changes:**
+**After (v0.2.0):**
 ```typescript
-// Before
-const infraStack = new pulumi.StackReference(`${org}/infrastructure/${stack}`);
-const vpcId = infraStack.requireOutput("vpcId");
+// infrastructure/index.ts
+import { createStackAlias } from "@egulatee/pulumi-stack-alias";
 
-// After
+const config = new pulumi.Config();
+const aliasTarget = config.get("aliasTarget");
+
+if (aliasTarget) {
+  const alias = createStackAlias({
+    targetProject: "infrastructure",
+    targetStack: aliasTarget,
+    outputs: ["vpcId", "endpoint"],
+  });
+
+  export const vpcId = alias.vpcId;
+  export const endpoint = alias.endpoint;
+} else {
+  export const vpcId = vpc.id;
+  export const endpoint = /* ... */;
+}
+```
+
+#### Consumer Changes
+
+**Before (v0.1.0):**
+```typescript
+import { resolveStackRef } from "@egulatee/pulumi-stack-alias";
+
 const infraStack = resolveStackRef("infrastructure");
 const vpcId = infraStack.apply(ref => ref.requireOutput("vpcId"));
 ```
+
+**After (v0.2.0):**
+```typescript
+// NO LIBRARY IMPORT NEEDED!
+const infraStack = new pulumi.StackReference(
+  `${pulumi.getOrganization()}/infrastructure/${pulumi.getStack()}`
+);
+const vpcId = infraStack.requireOutput("vpcId");
+```
+
+#### Migration Steps
+
+1. **Update package.json**: Bump to `@egulatee/pulumi-stack-alias@^0.2.0`
+2. **Update producer code**: Replace `_canonicalStack` exports with `createStackAlias()` calls
+3. **Update consumer code**: Replace `resolveStackRef()` with standard `new StackReference()`
+4. **Remove consumer dependency**: Uninstall `@egulatee/pulumi-stack-alias` from consumer projects
+5. **Redeploy all stacks**: Alias stacks need one-time redeployment to export new outputs
+6. **Set up CI/CD**: Add alias sync jobs to keep outputs fresh
 
 ## Contributing
 

--- a/examples/conditional-alias/index.ts
+++ b/examples/conditional-alias/index.ts
@@ -1,32 +1,30 @@
-import * as pulumi from "@pulumi/pulumi";
-import { createStackAlias, createConditionalAlias } from "@egulatee/pulumi-stack-alias";
+import { createConditionalAlias } from "@egulatee/pulumi-stack-alias";
 
 /**
- * Conditional alias example using stack configuration
+ * Conditional alias example using pattern matching
  *
- * This approach uses Pulumi config to determine whether this is an alias
- * stack or a canonical stack with actual resources.
+ * This example demonstrates how to use createConditionalAlias to automatically
+ * route different stacks to appropriate canonical stacks based on patterns.
+ *
+ * Pattern matching rules:
+ * - prod stacks -> infrastructure/prod
+ * - staging stacks -> infrastructure/shared
+ * - dev stacks -> infrastructure/shared
+ * - *-ephemeral stacks -> infrastructure/shared
  */
 
-const config = new pulumi.Config();
-const aliasTarget = config.get("aliasTarget");
+const alias = createConditionalAlias({
+  targetProject: "infrastructure",
+  patterns: [
+    { pattern: "*/prod", target: "prod" },
+    { pattern: "*/staging", target: "shared" },
+    { pattern: "*/dev", target: "shared" },
+    { pattern: "*/*-ephemeral", target: "shared" },
+  ],
+  defaultTarget: "shared",
+  outputs: ["vpcId", "endpoint", "clusterName"],
+});
 
-if (aliasTarget) {
-  // This is an alias stack - redirect to target
-  const alias = createStackAlias({
-    targetProject: "infrastructure",
-    targetStack: aliasTarget,
-    outputs: ["vpcId", "endpoint", "clusterName"],
-  });
-
-  export const vpcId = alias.vpcId;
-  export const endpoint = alias.endpoint;
-  export const clusterName = alias.clusterName;
-} else {
-  // This is a canonical stack - create actual resources
-  // (In a real implementation, this would create actual infrastructure resources)
-
-  export const vpcId = pulumi.output("vpc-12345678");
-  export const endpoint = pulumi.output("https://api.example.com");
-  export const clusterName = pulumi.output("my-cluster");
-}
+export const vpcId = alias.vpcId;
+export const endpoint = alias.endpoint;
+export const clusterName = alias.clusterName;

--- a/package.json
+++ b/package.json
@@ -1,12 +1,9 @@
 {
   "name": "@egulatee/pulumi-stack-alias",
-  "version": "0.1.0",
-  "description": "A generalized stack aliasing system for Pulumi that enables transparent stack references and environment mapping",
+  "version": "0.2.0",
+  "description": "Producer-side stack aliasing for Pulumi using lightweight proxy stacks",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "bin": {
-    "pulumi-alias": "dist/cli.js"
-  },
   "scripts": {
     "build": "tsc",
     "test": "vitest",
@@ -43,9 +40,6 @@
     "eslint": "^8.0.0",
     "typescript": "^5.0.0",
     "vitest": "^1.0.0"
-  },
-  "dependencies": {
-    "commander": "^11.0.0"
   },
   "engines": {
     "node": ">=18"

--- a/src/alias.ts
+++ b/src/alias.ts
@@ -1,95 +1,129 @@
 import * as pulumi from "@pulumi/pulumi";
-import { ResolveStackRefOptions, REDIRECT_KEY } from "./types";
+import {
+  AliasConfig,
+  AliasExports,
+  ConditionalAliasConfig,
+} from "./types";
 
 /**
- * Resolves a stack reference by checking for producer-controlled redirects
+ * Creates a stack alias that re-exports outputs from a target stack
  *
- * This function implements the Producer-Controlled Redirect pattern:
- * 1. Creates a StackReference to the target project using the current stack name
- * 2. Checks if the stack exports a `_canonicalStack` redirect pointer
- * 3. If redirect exists, follows it to the canonical stack
- * 4. Returns the canonical StackReference wrapped in Output
- *
- * The producer (infrastructure project) controls aliasing decisions by exporting
- * `_canonicalStack` in alias stacks. The consumer has zero knowledge of aliasing.
+ * This is the core function of the Producer-Controlled Proxy pattern.
+ * It creates a StackReference to the target stack and re-exports specified outputs.
  *
  * @example
  * ```typescript
- * // Consumer code (application/index.ts)
- * import { resolveStackRef } from "@egulatee/pulumi-stack-alias";
+ * // In alias stack infrastructure/dev
+ * import { createStackAlias } from "@egulatee/pulumi-stack-alias";
  *
- * const infraStack = resolveStackRef("infrastructure");
- * const vpcId = infraStack.apply(ref => ref.requireOutput("vpcId"));
+ * const alias = createStackAlias({
+ *   targetProject: "infrastructure",
+ *   targetStack: "shared",
+ *   outputs: ["vpcId", "clusterName", "endpoint"]
+ * });
  *
- * // When application/dev deploys:
- * // → reads infrastructure/dev
- * // → finds _canonicalStack: "shared"
- * // → returns StackReference to infrastructure/shared
- * // → vpcId is always fresh from canonical stack!
+ * export const vpcId = alias.vpcId;
+ * export const clusterName = alias.clusterName;
+ * export const endpoint = alias.endpoint;
  * ```
  *
- * @param project - Target project name (e.g., "infrastructure")
- * @param opts - Optional configuration
- * @returns Output containing the resolved StackReference
+ * @param config - Alias configuration
+ * @returns Record of Pulumi Outputs for each specified output name
  */
-export function resolveStackRef(
-  project: string,
-  opts?: ResolveStackRefOptions
-): pulumi.Output<pulumi.StackReference> {
-  const org = opts?.org || pulumi.getOrganization();
-  const stack = pulumi.getStack();
+export function createStackAlias(config: AliasConfig): AliasExports {
+  const org = config.targetOrg || pulumi.getOrganization();
+  const targetStackName = `${org}/${config.targetProject}/${config.targetStack}`;
+  const targetStack = new pulumi.StackReference(targetStackName);
 
-  // Create initial reference to project/currentStack
-  const initialStackName = `${org}/${project}/${stack}`;
-  const initialRef = new pulumi.StackReference(initialStackName);
+  const exports: AliasExports = {};
+  for (const outputName of config.outputs) {
+    exports[outputName] = targetStack.requireOutput(outputName);
+  }
 
-  // Check for redirect pointer
-  return initialRef.getOutput(REDIRECT_KEY).apply((canonical) => {
-    if (canonical && typeof canonical === "string") {
-      // Redirect exists — follow it to the canonical stack
-      const canonicalStackName = `${org}/${project}/${canonical}`;
-      return new pulumi.StackReference(canonicalStackName);
+  return exports;
+}
+
+/**
+ * Creates a conditional alias based on pattern matching
+ *
+ * Evaluates pattern rules in order and uses the first matching target.
+ * Falls back to defaultTarget if no pattern matches.
+ *
+ * @example
+ * ```typescript
+ * // In infrastructure/index.ts
+ * import { createConditionalAlias } from "@egulatee/pulumi-stack-alias";
+ *
+ * const alias = createConditionalAlias({
+ *   targetProject: "infrastructure",
+ *   patterns: [
+ *     { pattern: "*\/prod", target: "prod" },
+ *     { pattern: "*\/staging", target: "shared" },
+ *     { pattern: "*\/*-ephemeral", target: "shared" }
+ *   ],
+ *   defaultTarget: "shared",
+ *   outputs: ["vpcId", "endpoint"]
+ * });
+ *
+ * export const vpcId = alias.vpcId;
+ * export const endpoint = alias.endpoint;
+ * ```
+ *
+ * @param config - Conditional alias configuration
+ * @returns Record of Pulumi Outputs for each specified output name
+ */
+export function createConditionalAlias(config: ConditionalAliasConfig): AliasExports {
+  const currentProject = pulumi.getProject();
+  const currentStack = pulumi.getStack();
+
+  // Find first matching pattern
+  let targetStack = config.defaultTarget;
+  for (const rule of config.patterns) {
+    if (matchesPattern(rule.pattern, currentProject, currentStack)) {
+      targetStack = rule.target;
+      break;
     }
+  }
 
-    // No redirect — this is already the canonical stack
-    return initialRef;
+  if (!targetStack) {
+    throw new Error(
+      `No matching pattern found for ${currentProject}/${currentStack} ` +
+      `and no defaultTarget specified.`
+    );
+  }
+
+  return createStackAlias({
+    targetProject: config.targetProject,
+    targetStack: targetStack,
+    targetOrg: config.targetOrg,
+    outputs: config.outputs,
   });
 }
 
 /**
- * Helper function for producer projects to export canonical stack pointer
+ * Creates a simple alias using a simplified API
  *
- * Use this in your producer project's index.ts to conditionally export
- * the redirect pointer based on configuration.
+ * Convenience wrapper around createStackAlias for common use cases.
  *
  * @example
  * ```typescript
- * // infrastructure/index.ts
- * import { exportCanonicalPointer } from "@egulatee/pulumi-stack-alias";
+ * import { createSimpleAlias } from "@egulatee/pulumi-stack-alias";
  *
- * const config = new pulumi.Config();
- * const aliasTarget = config.get("aliasTarget");
- *
- * if (aliasTarget) {
- *   // This is an alias stack — export only the redirect pointer
- *   exportCanonicalPointer(aliasTarget);
- * } else {
- *   // This is a canonical stack — create actual resources
- *   export const vpcId = myVpc.id;
- *   export const clusterName = pulumi.output("my-cluster");
- * }
+ * const alias = createSimpleAlias("infrastructure", "shared", ["vpcId"]);
+ * export const vpcId = alias.vpcId;
  * ```
  *
- * @param _canonicalStackName - The name of the canonical stack to redirect to
+ * @param targetProject - Target project name
+ * @param targetStack - Target stack name
+ * @param outputs - List of output names to re-export
+ * @returns Record of Pulumi Outputs for each specified output name
  */
-export function exportCanonicalPointer(_canonicalStackName: string): void {
-  // This function is meant to be used with dynamic exports
-  // The caller should use: export const _canonicalStack = result
-  // We'll just log for now, but the real pattern is direct export
-  throw new Error(
-    `exportCanonicalPointer should not be called directly. ` +
-    `Instead, use: export const ${REDIRECT_KEY} = aliasTarget;`
-  );
+export function createSimpleAlias(
+  targetProject: string,
+  targetStack: string,
+  outputs: string[]
+): AliasExports {
+  return createStackAlias({ targetProject, targetStack, outputs });
 }
 
 /**
@@ -120,6 +154,12 @@ export function exportCanonicalPointer(_canonicalStackName: string): void {
  */
 export function matchesPattern(pattern: string, project: string, stack: string): boolean {
   const [projectPattern, stackPattern] = pattern.split("/");
+
+  if (!projectPattern || !stackPattern) {
+    throw new Error(
+      `Invalid pattern format: "${pattern}". Expected "projectPattern/stackPattern".`
+    );
+  }
 
   const projectMatches = matchesWildcard(projectPattern, project);
   const stackMatches = matchesWildcard(stackPattern, stack);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,28 +1,32 @@
 /**
  * @egulatee/pulumi-stack-alias
  *
- * A lightweight stack resolver library for Pulumi that enables producer-controlled
- * stack aliasing through redirect pointers. Eliminates output staleness and
- * operational overhead by using lightweight alias stacks that export only a
- * redirect pointer to the canonical stack.
+ * Producer-side stack aliasing for Pulumi using lightweight proxy stacks.
  *
- * ## Producer-Controlled Redirect Pattern
+ * Consumers use standard StackReference (no library dependency).
+ * Producers use this library to create alias stacks that re-export outputs.
  *
- * Alias stacks export a `_canonicalStack` pointer. The consumer-side resolver
- * transparently follows redirects to reach the canonical stack, ensuring outputs
- * are always fresh.
+ * ## Producer-Controlled Proxy Pattern
+ *
+ * Alias stacks re-export outputs from canonical stacks. Consumers use standard
+ * Pulumi StackReference without any library dependency. Producers use this
+ * library to create proxy stacks that keep outputs in sync.
  *
  * @packageDocumentation
  */
 
 export {
-  resolveStackRef,
+  createStackAlias,
+  createConditionalAlias,
+  createSimpleAlias,
   matchesPattern,
 } from "./alias";
 
-export {
-  ResolveStackRefOptions,
-  REDIRECT_KEY,
+export type {
+  AliasConfig,
+  AliasExports,
+  PatternRule,
+  ConditionalAliasConfig,
 } from "./types";
 
 // Re-export Pulumi types for convenience

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,37 +1,77 @@
 import * as pulumi from "@pulumi/pulumi";
 
 /**
- * The output key used to indicate a stack is an alias pointing to a canonical stack
+ * Configuration for creating a stack alias
  */
-export const REDIRECT_KEY = "_canonicalStack";
-
-/**
- * Options for resolveStackRef function
- */
-export interface ResolveStackRefOptions {
+export interface AliasConfig {
   /**
-   * Target organization name
-   * @default pulumi.getOrganization()
+   * Target organization name (defaults to current organization)
    */
-  org?: string;
+  targetOrg?: string;
+
+  /**
+   * Target project name
+   */
+  targetProject: string;
+
+  /**
+   * Target stack name
+   */
+  targetStack: string;
+
+  /**
+   * List of output names to re-export from the target stack
+   */
+  outputs: string[];
 }
 
 /**
- * Result of stack resolution containing the canonical stack reference
+ * Record of aliased outputs (all are Pulumi Outputs)
  */
-export interface ResolvedStack {
+export type AliasExports = Record<string, pulumi.Output<any>>;
+
+/**
+ * A pattern rule for conditional aliasing
+ */
+export interface PatternRule {
   /**
-   * The canonical stack reference (after following any redirects)
+   * Pattern in format "project/stack" with wildcard support
+   * Examples: "* /prod", "myproject/ *", "* / *-ephemeral" (without spaces)
    */
-  stackRef: pulumi.StackReference;
+  pattern: string;
 
   /**
-   * Whether a redirect was followed (true if alias, false if canonical)
+   * Target stack name to use when this pattern matches
    */
-  wasRedirected: boolean;
+  target: string;
+}
+
+/**
+ * Configuration for creating a conditional alias based on pattern matching
+ */
+export interface ConditionalAliasConfig {
+  /**
+   * Target project name
+   */
+  targetProject: string;
 
   /**
-   * The final stack name that was resolved
+   * Target organization name (defaults to current organization)
    */
-  resolvedStackName: string;
+  targetOrg?: string;
+
+  /**
+   * List of pattern rules (evaluated in order, first match wins)
+   */
+  patterns: PatternRule[];
+
+  /**
+   * Default target stack if no pattern matches (optional)
+   */
+  defaultTarget?: string;
+
+  /**
+   * List of output names to re-export from the target stack
+   */
+  outputs: string[];
 }

--- a/tests/alias.test.ts
+++ b/tests/alias.test.ts
@@ -1,7 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import * as pulumi from "@pulumi/pulumi";
-import { resolveStackRef, matchesPattern } from "../src/alias";
-import { REDIRECT_KEY } from "../src/types";
+import {
+  matchesPattern,
+  createStackAlias,
+  createConditionalAlias,
+  createSimpleAlias,
+} from "../src/alias";
 
 // Mock Pulumi runtime functions
 vi.mock("@pulumi/pulumi", async () => {
@@ -69,32 +73,168 @@ describe("Pattern Matching", () => {
       expect(matchesPattern("MyProject/Dev", "MyProject", "Dev")).toBe(true);
       expect(matchesPattern("MyProject/Dev", "myproject", "dev")).toBe(false);
     });
+
+    it("should throw error for invalid pattern format", () => {
+      expect(() => matchesPattern("invalid", "project", "stack")).toThrow(
+        'Invalid pattern format: "invalid". Expected "projectPattern/stackPattern".'
+      );
+      expect(() => matchesPattern("project/", "project", "stack")).toThrow(
+        'Invalid pattern format: "project/". Expected "projectPattern/stackPattern".'
+      );
+      expect(() => matchesPattern("/stack", "project", "stack")).toThrow(
+        'Invalid pattern format: "/stack". Expected "projectPattern/stackPattern".'
+      );
+    });
   });
 });
 
-describe("resolveStackRef", () => {
+describe("createStackAlias", () => {
   let mockStackReference: any;
-  let mockGetOutput: any;
+  let mockRequireOutput: any;
 
   beforeEach(() => {
     vi.clearAllMocks();
 
-    // Mock getOutput to return an Output-like object
-    mockGetOutput = vi.fn();
+    mockRequireOutput = vi.fn();
 
-    // Mock StackReference constructor
     mockStackReference = vi.fn().mockImplementation((stackName: string) => {
       return {
         stackName,
-        getOutput: mockGetOutput,
-        requireOutput: vi.fn(),
+        requireOutput: mockRequireOutput,
       };
     });
 
     (pulumi.StackReference as any).mockImplementation(mockStackReference);
-
-    // Reset runtime mocks
     (pulumi.getOrganization as any).mockReturnValue("test-org");
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should create StackReference with correct full name", () => {
+    mockRequireOutput.mockReturnValue(pulumi.output("test-value"));
+
+    createStackAlias({
+      targetProject: "infrastructure",
+      targetStack: "shared",
+      outputs: ["vpcId"],
+    });
+
+    expect(mockStackReference).toHaveBeenCalledWith("test-org/infrastructure/shared");
+  });
+
+  it("should use custom org when provided", () => {
+    mockRequireOutput.mockReturnValue(pulumi.output("test-value"));
+
+    createStackAlias({
+      targetOrg: "custom-org",
+      targetProject: "infrastructure",
+      targetStack: "shared",
+      outputs: ["vpcId"],
+    });
+
+    expect(mockStackReference).toHaveBeenCalledWith("custom-org/infrastructure/shared");
+  });
+
+  it("should re-export all specified outputs", () => {
+    mockRequireOutput.mockReturnValue(pulumi.output("test-value"));
+
+    createStackAlias({
+      targetProject: "infrastructure",
+      targetStack: "shared",
+      outputs: ["vpcId", "endpoint", "clusterName"],
+    });
+
+    expect(mockRequireOutput).toHaveBeenCalledWith("vpcId");
+    expect(mockRequireOutput).toHaveBeenCalledWith("endpoint");
+    expect(mockRequireOutput).toHaveBeenCalledWith("clusterName");
+    expect(mockRequireOutput).toHaveBeenCalledTimes(3);
+  });
+
+  it("should return Pulumi Outputs", () => {
+    const outputValue = pulumi.output("test-value");
+    mockRequireOutput.mockReturnValue(outputValue);
+
+    const result = createStackAlias({
+      targetProject: "infrastructure",
+      targetStack: "shared",
+      outputs: ["vpcId"],
+    });
+
+    expect(result.vpcId).toBe(outputValue);
+  });
+
+  it("should handle empty outputs array", () => {
+    const result = createStackAlias({
+      targetProject: "infrastructure",
+      targetStack: "shared",
+      outputs: [],
+    });
+
+    expect(result).toEqual({});
+    expect(mockRequireOutput).not.toHaveBeenCalled();
+  });
+
+  it("should work with single output", () => {
+    mockRequireOutput.mockReturnValue(pulumi.output("test-value"));
+
+    const result = createStackAlias({
+      targetProject: "infrastructure",
+      targetStack: "shared",
+      outputs: ["vpcId"],
+    });
+
+    expect(Object.keys(result)).toHaveLength(1);
+    expect(result.vpcId).toBeDefined();
+  });
+
+  it("should work with many outputs", () => {
+    mockRequireOutput.mockReturnValue(pulumi.output("test-value"));
+
+    const result = createStackAlias({
+      targetProject: "infrastructure",
+      targetStack: "shared",
+      outputs: ["output1", "output2", "output3", "output4", "output5"],
+    });
+
+    expect(Object.keys(result)).toHaveLength(5);
+    expect(mockRequireOutput).toHaveBeenCalledTimes(5);
+  });
+
+  it("should use requireOutput instead of getOutput", () => {
+    mockRequireOutput.mockReturnValue(pulumi.output("test-value"));
+
+    createStackAlias({
+      targetProject: "infrastructure",
+      targetStack: "shared",
+      outputs: ["vpcId"],
+    });
+
+    // Verify requireOutput was called (not getOutput)
+    expect(mockRequireOutput).toHaveBeenCalled();
+  });
+});
+
+describe("createConditionalAlias", () => {
+  let mockStackReference: any;
+  let mockRequireOutput: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockRequireOutput = vi.fn().mockReturnValue(pulumi.output("test-value"));
+
+    mockStackReference = vi.fn().mockImplementation((stackName: string) => {
+      return {
+        stackName,
+        requireOutput: mockRequireOutput,
+      };
+    });
+
+    (pulumi.StackReference as any).mockImplementation(mockStackReference);
+    (pulumi.getOrganization as any).mockReturnValue("test-org");
+    (pulumi.getProject as any).mockReturnValue("test-project");
     (pulumi.getStack as any).mockReturnValue("dev");
   });
 
@@ -102,156 +242,222 @@ describe("resolveStackRef", () => {
     vi.restoreAllMocks();
   });
 
-  it("should follow redirect when _canonicalStack is present", async () => {
-    // Mock getOutput to return a redirect pointer
-    mockGetOutput.mockReturnValue(
-      pulumi.output("shared") // Redirect to "shared" stack
-    );
+  it("should use first matching pattern", () => {
+    createConditionalAlias({
+      targetProject: "infrastructure",
+      patterns: [
+        { pattern: "*/dev", target: "shared" },
+        { pattern: "*/staging", target: "shared" },
+        { pattern: "*/prod", target: "prod" },
+      ],
+      outputs: ["vpcId"],
+    });
 
-    const result = resolveStackRef("infrastructure");
-
-    // Verify initial reference was created
-    expect(mockStackReference).toHaveBeenCalledWith("test-org/infrastructure/dev");
-
-    // Verify getOutput was called with REDIRECT_KEY
-    expect(mockGetOutput).toHaveBeenCalledWith(REDIRECT_KEY);
-
-    // Resolve the output to get the final StackReference
-    const resolved = await result.promise();
-
-    // Verify redirect was followed and second StackReference was created
     expect(mockStackReference).toHaveBeenCalledWith("test-org/infrastructure/shared");
-    expect(resolved.stackName).toBe("test-org/infrastructure/shared");
   });
 
-  it("should return initial reference when no redirect exists", async () => {
-    // Mock getOutput to return undefined (no redirect)
-    mockGetOutput.mockReturnValue(pulumi.output(undefined));
+  it("should evaluate patterns in order", () => {
+    (pulumi.getStack as any).mockReturnValue("prod");
 
-    const result = resolveStackRef("infrastructure");
+    createConditionalAlias({
+      targetProject: "infrastructure",
+      patterns: [
+        { pattern: "*/staging", target: "shared" },
+        { pattern: "*/prod", target: "prod" },
+        { pattern: "*/*", target: "fallback" },
+      ],
+      outputs: ["vpcId"],
+    });
 
-    // Verify initial reference was created
-    expect(mockStackReference).toHaveBeenCalledWith("test-org/infrastructure/dev");
-
-    // Resolve the output
-    const resolved = await result.promise();
-
-    // Verify no second StackReference was created
-    expect(mockStackReference).toHaveBeenCalledTimes(1);
-    expect(resolved.stackName).toBe("test-org/infrastructure/dev");
+    expect(mockStackReference).toHaveBeenCalledWith("test-org/infrastructure/prod");
   });
 
-  it("should return initial reference when redirect is null", async () => {
-    mockGetOutput.mockReturnValue(pulumi.output(null));
+  it("should use defaultTarget when no pattern matches", () => {
+    (pulumi.getStack as any).mockReturnValue("unknown-stack");
 
-    const result = resolveStackRef("infrastructure");
-    const resolved = await result.promise();
+    createConditionalAlias({
+      targetProject: "infrastructure",
+      patterns: [
+        { pattern: "*/dev", target: "shared" },
+        { pattern: "*/prod", target: "prod" },
+      ],
+      defaultTarget: "fallback",
+      outputs: ["vpcId"],
+    });
 
-    expect(mockStackReference).toHaveBeenCalledTimes(1);
-    expect(resolved.stackName).toBe("test-org/infrastructure/dev");
+    expect(mockStackReference).toHaveBeenCalledWith("test-org/infrastructure/fallback");
   });
 
-  it("should return initial reference when redirect is empty string", async () => {
-    mockGetOutput.mockReturnValue(pulumi.output(""));
+  it("should throw error when no pattern matches and no defaultTarget", () => {
+    (pulumi.getStack as any).mockReturnValue("unknown-stack");
 
-    const result = resolveStackRef("infrastructure");
-    const resolved = await result.promise();
-
-    expect(mockStackReference).toHaveBeenCalledTimes(1);
-    expect(resolved.stackName).toBe("test-org/infrastructure/dev");
+    expect(() => {
+      createConditionalAlias({
+        targetProject: "infrastructure",
+        patterns: [
+          { pattern: "*/dev", target: "shared" },
+          { pattern: "*/prod", target: "prod" },
+        ],
+        outputs: ["vpcId"],
+      });
+    }).toThrow("No matching pattern found for test-project/unknown-stack");
   });
 
-  it("should ignore non-string redirect values", async () => {
-    // Mock getOutput to return a number (invalid redirect)
-    mockGetOutput.mockReturnValue(pulumi.output(123));
+  it("should work with complex pattern rules", () => {
+    (pulumi.getProject as any).mockReturnValue("app-service");
+    (pulumi.getStack as any).mockReturnValue("feature-ephemeral");
 
-    const result = resolveStackRef("infrastructure");
-    const resolved = await result.promise();
+    createConditionalAlias({
+      targetProject: "infrastructure",
+      patterns: [
+        { pattern: "app-*/*-ephemeral", target: "shared" },
+        { pattern: "*/prod", target: "prod" },
+      ],
+      outputs: ["vpcId"],
+    });
 
-    // Should not follow redirect for non-string values
-    expect(mockStackReference).toHaveBeenCalledTimes(1);
-    expect(resolved.stackName).toBe("test-org/infrastructure/dev");
+    expect(mockStackReference).toHaveBeenCalledWith("test-org/infrastructure/shared");
   });
 
-  it("should use custom org when provided", async () => {
-    mockGetOutput.mockReturnValue(pulumi.output(undefined));
+  it("should support custom organization", () => {
+    createConditionalAlias({
+      targetProject: "infrastructure",
+      targetOrg: "custom-org",
+      patterns: [{ pattern: "*/dev", target: "shared" }],
+      outputs: ["vpcId"],
+    });
 
-    const result = resolveStackRef("infrastructure", { org: "custom-org" });
-
-    expect(mockStackReference).toHaveBeenCalledWith("custom-org/infrastructure/dev");
-  });
-
-  it("should use custom org when following redirect", async () => {
-    mockGetOutput.mockReturnValue(pulumi.output("shared"));
-
-    const result = resolveStackRef("infrastructure", { org: "custom-org" });
-    await result.promise();
-
-    expect(mockStackReference).toHaveBeenCalledWith("custom-org/infrastructure/dev");
     expect(mockStackReference).toHaveBeenCalledWith("custom-org/infrastructure/shared");
   });
 
-  it("should work with different stack names", async () => {
+  it("should re-export all specified outputs", () => {
+    createConditionalAlias({
+      targetProject: "infrastructure",
+      patterns: [{ pattern: "*/dev", target: "shared" }],
+      outputs: ["vpcId", "endpoint", "clusterName"],
+    });
+
+    expect(mockRequireOutput).toHaveBeenCalledWith("vpcId");
+    expect(mockRequireOutput).toHaveBeenCalledWith("endpoint");
+    expect(mockRequireOutput).toHaveBeenCalledWith("clusterName");
+  });
+
+  it("should work with different stack contexts", () => {
     (pulumi.getStack as any).mockReturnValue("staging");
-    mockGetOutput.mockReturnValue(pulumi.output("shared"));
 
-    const result = resolveStackRef("infrastructure");
-    await result.promise();
+    createConditionalAlias({
+      targetProject: "infrastructure",
+      patterns: [
+        { pattern: "*/dev", target: "dev" },
+        { pattern: "*/staging", target: "staging-canonical" },
+        { pattern: "*/prod", target: "prod" },
+      ],
+      outputs: ["vpcId"],
+    });
 
-    expect(mockStackReference).toHaveBeenCalledWith("test-org/infrastructure/staging");
-    expect(mockStackReference).toHaveBeenCalledWith("test-org/infrastructure/shared");
+    expect(mockStackReference).toHaveBeenCalledWith("test-org/infrastructure/staging-canonical");
   });
 
-  it("should work with prod stack (no redirect)", async () => {
-    (pulumi.getStack as any).mockReturnValue("prod");
-    mockGetOutput.mockReturnValue(pulumi.output(undefined));
+  it("should delegate to createStackAlias", () => {
+    const result = createConditionalAlias({
+      targetProject: "infrastructure",
+      patterns: [{ pattern: "*/dev", target: "shared" }],
+      outputs: ["vpcId"],
+    });
 
-    const result = resolveStackRef("infrastructure");
-    const resolved = await result.promise();
-
-    expect(mockStackReference).toHaveBeenCalledWith("test-org/infrastructure/prod");
-    expect(mockStackReference).toHaveBeenCalledTimes(1);
-    expect(resolved.stackName).toBe("test-org/infrastructure/prod");
+    // Verify it returns the same shape as createStackAlias
+    expect(result).toHaveProperty("vpcId");
+    expect(result.vpcId).toBeDefined();
   });
 
-  it("should return Output<StackReference>", () => {
-    mockGetOutput.mockReturnValue(pulumi.output(undefined));
+  it("should match using current project and stack", () => {
+    (pulumi.getProject as any).mockReturnValue("specific-project");
+    (pulumi.getStack as any).mockReturnValue("specific-stack");
 
-    const result = resolveStackRef("infrastructure");
+    createConditionalAlias({
+      targetProject: "infrastructure",
+      patterns: [
+        { pattern: "specific-project/specific-stack", target: "matched" },
+        { pattern: "*/*", target: "fallback" },
+      ],
+      outputs: ["vpcId"],
+    });
 
-    // Verify it's a Pulumi Output
-    expect(result).toHaveProperty("apply");
-    expect(typeof result.apply).toBe("function");
+    expect(mockStackReference).toHaveBeenCalledWith("test-org/infrastructure/matched");
   });
+});
 
-  it("should handle chained redirects", async () => {
-    // First call returns redirect to "intermediate"
-    // Second call returns redirect to "final"
-    const firstCall = vi.fn().mockReturnValue(pulumi.output("intermediate"));
-    const secondCall = vi.fn().mockReturnValue(pulumi.output("final"));
+describe("createSimpleAlias", () => {
+  let mockStackReference: any;
+  let mockRequireOutput: any;
 
-    let callCount = 0;
-    mockStackReference.mockImplementation((stackName: string) => {
-      const getOutput = callCount === 0 ? firstCall : secondCall;
-      callCount++;
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockRequireOutput = vi.fn().mockReturnValue(pulumi.output("test-value"));
+
+    mockStackReference = vi.fn().mockImplementation((stackName: string) => {
       return {
         stackName,
-        getOutput,
-        requireOutput: vi.fn(),
+        requireOutput: mockRequireOutput,
       };
     });
 
-    const result = resolveStackRef("infrastructure");
-    const resolved = await result.promise();
+    (pulumi.StackReference as any).mockImplementation(mockStackReference);
+    (pulumi.getOrganization as any).mockReturnValue("test-org");
+  });
 
-    // Should create initial reference to dev
-    expect(mockStackReference).toHaveBeenNthCalledWith(1, "test-org/infrastructure/dev");
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
 
-    // Should follow first redirect to intermediate
-    expect(mockStackReference).toHaveBeenNthCalledWith(2, "test-org/infrastructure/intermediate");
+  it("should create alias with simplified API", () => {
+    createSimpleAlias("infrastructure", "shared", ["vpcId"]);
 
-    // Note: Current implementation only follows one level of redirect
-    // If we want to support chained redirects, we'd need to make it recursive
-    expect(resolved.stackName).toBe("test-org/infrastructure/intermediate");
+    expect(mockStackReference).toHaveBeenCalledWith("test-org/infrastructure/shared");
+    expect(mockRequireOutput).toHaveBeenCalledWith("vpcId");
+  });
+
+  it("should use current organization", () => {
+    (pulumi.getOrganization as any).mockReturnValue("my-org");
+
+    createSimpleAlias("infrastructure", "shared", ["vpcId"]);
+
+    expect(mockStackReference).toHaveBeenCalledWith("my-org/infrastructure/shared");
+  });
+
+  it("should work with single output", () => {
+    const result = createSimpleAlias("infrastructure", "shared", ["vpcId"]);
+
+    expect(Object.keys(result)).toHaveLength(1);
+    expect(result.vpcId).toBeDefined();
+  });
+
+  it("should work with many outputs", () => {
+    const result = createSimpleAlias("infrastructure", "shared", [
+      "vpcId",
+      "endpoint",
+      "clusterName",
+    ]);
+
+    expect(Object.keys(result)).toHaveLength(3);
+    expect(result.vpcId).toBeDefined();
+    expect(result.endpoint).toBeDefined();
+    expect(result.clusterName).toBeDefined();
+  });
+
+  it("should return Pulumi Outputs", () => {
+    const result = createSimpleAlias("infrastructure", "shared", ["vpcId"]);
+
+    expect(result.vpcId).toBeDefined();
+    expect(mockRequireOutput).toHaveBeenCalledWith("vpcId");
+  });
+
+  it("should delegate to createStackAlias", () => {
+    const result = createSimpleAlias("infrastructure", "shared", ["vpcId"]);
+
+    // Verify it returns the same shape as createStackAlias
+    expect(result).toHaveProperty("vpcId");
+    expect(mockStackReference).toHaveBeenCalledWith("test-org/infrastructure/shared");
   });
 });


### PR DESCRIPTION
## Summary

Complete rollback from Producer-Controlled Redirect pattern (v0.1.0) to Producer-Controlled Proxy Stack pattern (v0.2.0). This implements the pattern described in Issue #13.

**Breaking change**: Complete API rewrite.

## What Changed

### Removed (Redirect Pattern)
- ❌ `resolveStackRef()` - Consumer-side resolver function
- ❌ `exportCanonicalPointer()` - Producer helper function
- ❌ `REDIRECT_KEY` constant
- ❌ `ResolveStackRefOptions`, `ResolvedStack` types

### Added (Proxy Pattern)
- ✅ `createStackAlias()` - Producer-side alias creation
- ✅ `createConditionalAlias()` - Pattern-based conditional aliasing
- ✅ `createSimpleAlias()` - Simplified API wrapper
- ✅ New types: `AliasConfig`, `AliasExports`, `PatternRule`, `ConditionalAliasConfig`

### Package Changes
- ✅ Removed CLI tooling and `commander` dependency
- ✅ Bumped version to 0.2.0
- ✅ Updated description

## Why This Change?

**Current Pattern (Redirect - v0.1.0):**
- Consumer imports library and uses `resolveStackRef()`
- Alias stacks export `_canonicalStack` redirect pointer
- Always-fresh outputs (reads from canonical stack)
- Consumer **requires library dependency** ⚠️

**New Pattern (Proxy - v0.2.0):**
- Consumer uses standard `new StackReference()` - **NO library dependency** ✅
- Alias stacks re-export all outputs from canonical stack
- Outputs captured at deploy time (must sync in CI)
- Producer uses library to create proxy stacks

**User preference**: Zero consumer dependencies, even with CI/CD orchestration trade-off.

## Example Code Changes

### Consumer Side

**Before (v0.1.0):**
```typescript
import { resolveStackRef } from "@egulatee/pulumi-stack-alias";

const infraStack = resolveStackRef("infrastructure");
const vpcId = infraStack.apply(ref => ref.requireOutput("vpcId"));
```

**After (v0.2.0):**
```typescript
// NO LIBRARY IMPORT - standard Pulumi!
const infraStack = new pulumi.StackReference(
  `${pulumi.getOrganization()}/infrastructure/${pulumi.getStack()}`
);
const vpcId = infraStack.requireOutput("vpcId");
```

### Producer Side

**Before (v0.1.0):**
```typescript
if (aliasTarget) {
  export const _canonicalStack = aliasTarget;
}
```

**After (v0.2.0):**
```typescript
import { createStackAlias } from "@egulatee/pulumi-stack-alias";

if (aliasTarget) {
  const alias = createStackAlias({
    targetProject: "infrastructure",
    targetStack: aliasTarget,
    outputs: ["vpcId", "endpoint"],
  });
  
  export const vpcId = alias.vpcId;
  export const endpoint = alias.endpoint;
}
```

## Files Changed

- `src/types.ts` - New proxy pattern types
- `src/alias.ts` - New proxy functions (kept pattern matching)
- `src/index.ts` - Updated exports
- `tests/alias.test.ts` - 33 tests (9 pattern + 24 proxy)
- `examples/conditional-alias/index.ts` - Updated example
- `package.json` - Removed CLI, bumped version
- `README.md` - Complete rewrite with CI/CD guidance

## Test Plan

- [x] All 33 unit tests passing
- [x] TypeScript builds cleanly
- [x] Linter passes (1 expected warning for `any` type)
- [x] Pattern matching tests maintained
- [x] New proxy function tests added
- [x] Examples updated

## Breaking Changes ⚠️

This is a **complete breaking change**. Migration required:

1. **Consumers**: Remove library dependency, use standard `StackReference`
2. **Producers**: Update to use `createStackAlias()` API
3. **Deployment**: Redeploy all alias stacks to export new outputs
4. **CI/CD**: Add alias sync jobs for keeping outputs fresh

See README migration guide for details.

## Benefits

✅ Zero consumer library dependency
✅ Standard Pulumi patterns
✅ Producer-controlled aliasing maintained
✅ Type-safe API
✅ Flexible pattern matching

## Trade-offs

⚠️ Alias stacks need redeployment when canonical outputs change
⚠️ Requires CI/CD orchestration (documented in README)
⚠️ Slightly more operational overhead vs redirect pattern

However: Alias deployments are fast (seconds) - no real resources created.

## CI/CD Strategy

README includes comprehensive CI/CD orchestration guide:

```yaml
jobs:
  deploy-canonical:
    # Deploy canonical stacks
    
  sync-aliases:
    needs: deploy-canonical
    strategy:
      matrix:
        stack: [dev, staging]
    # Fast parallel alias sync
```

---

Addresses: #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)